### PR TITLE
Explicitly define module position

### DIFF
--- a/resources/Resources.php
+++ b/resources/Resources.php
@@ -18,6 +18,7 @@ return call_user_func( function() {
 
 	$modules = array(
 		'ext.wikimediaBadges' => $moduleTemplate + array(
+			'position' => 'top',
 			'skinStyles' => array(
 				'vector' => 'skins/vector/wikimedia-badges.css',
 				'monobook' => 'skins/monobook/wikimedia-badges.css',


### PR DESCRIPTION
Style modules currently added through addModuleStyles default to being in the head ("top" position). This is an unhealthy default, since only critical styles that are needed at pageload should be in the head. In order to be able to switch the default to "bottom", existing module positions have to be defined explicitly.

[Bug: T97410](https://phabricator.wikimedia.org/T97410)